### PR TITLE
Fixing bug with oversized packets

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -364,10 +364,8 @@ func (c *Connection) sendSpecialClearPacket(pt uint8, connId ConnectionId, pn ui
 	return nil
 }
 
-func (c *Connection) sendPacketRaw(pt uint8, connId ConnectionId, pn uint64, version VersionNumber, payload []byte) error {
-	c.log(logTypeConnection, "Sending packet PT=%v PN=%x: %s", pt, c.nextSendPacket, dumpPacket(payload))
-	left := c.mtu
-	var aead cipher.AEAD
+func (c *Connection) determineAead(pt uint8) cipher.AEAD {
+var aead cipher.AEAD
 	if c.writeProtected != nil {
 		aead = c.writeProtected.aead
 	}
@@ -387,6 +385,14 @@ func (c *Connection) sendPacketRaw(pt uint8, connId ConnectionId, pn uint64, ver
 		}
 	}
 
+	return aead
+}
+
+func (c *Connection) sendPacketRaw(pt uint8, connId ConnectionId, pn uint64, version VersionNumber, payload []byte) error {
+	c.log(logTypeConnection, "Sending packet PT=%v PN=%x: %s", pt, c.nextSendPacket, dumpPacket(payload))
+	left := c.mtu /* track how much space is left for payload */
+
+	aead := c.determineAead(pt)
 	left -= aead.Overhead()
 
 	// For now, just do the long header.
@@ -403,7 +409,7 @@ func (c *Connection) sendPacketRaw(pt uint8, connId ConnectionId, pn uint64, ver
 	// Encode the header so we know how long it is.
 	// TODO(ekr@rtfm.com): this is gross.
 	hdr, err := encode(&p.packetHeader)
-	if err != nil {
+ 	if err != nil {
 		return err
 	}
 	left -= len(hdr)
@@ -613,9 +619,13 @@ func (c *Connection) sendQueued(bareAcks bool) (int, error) {
 
 // Send a packet of stream frames, plus whatever acks fit.
 func (c *Connection) sendCombinedPacket(pt uint8, frames []frame, acks ackRanges) (int, error) {
-	left := c.mtu
 	asent := int(0)
 	var err error
+
+	left := c.mtu
+	aead := c.determineAead(pt)
+	left -= aead.Overhead()
+	left -= kLongHeaderLength //TODO make this check if we are using a long or short header
 
 	for _, f := range frames {
 		l, err := f.length()
@@ -654,12 +664,14 @@ func (c *Connection) queueFrame(q *[]frame, f frame) {
 func (c *Connection) queueStreamFrames(pt uint8, protected bool, bareAcks bool) (int, error) {
 	c.log(logTypeConnection, "%v: sendQueuedStreamData pt=%v, protected=%v",
 		c.label(), pt, protected)
-	left := c.mtu
 	frames := make([]frame, 0)
 	sent := int(0)
 	acks := c.recvd.prepareAckRange(protected, false)
 	now := time.Now()
 	txAge := time.Duration(c.retransmitTime) * time.Millisecond
+
+	aeadOverhead :=  c.determineAead(pt).Overhead()
+	left := c.mtu - aeadOverhead - kLongHeaderLength // TODO: check header type
 
 	var streams []*Stream
 	var q *[]frame
@@ -712,7 +724,7 @@ func (c *Connection) queueStreamFrames(pt uint8, protected bool, bareAcks bool) 
 
 			acks = acks[asent:]
 			frames = make([]frame, 0)
-			left = c.mtu
+			left = c.mtu - aeadOverhead - kLongHeaderLength // TODO: check header type
 		}
 
 		frames = append(frames, *f)


### PR DESCRIPTION
When selecting the number of frames and acks to be transmitted,
the header size and AEAD overhead were not considered when determining
the space left in the packet.