### PR TITLE
ACK ranges

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -580,10 +580,6 @@ func (c *Connection) sendOnStream(streamId uint32, data []byte) error {
 }
 
 func (c *Connection) makeAckFrame(acks ackRanges, maxackblocks uint8) (*frame, int, error) {
-//	if len(acks) > maxackblocks {
-//		acks = acks[:maxackblocks]
-//	}
-
 	af, rangesSent, err := newAckFrame(acks, maxackblocks)
 	if err != nil {
 		c.log(logTypeConnection, "Couldn't prepare ACK frame %v", err)
@@ -1463,7 +1459,7 @@ func (c *Connection) processAckFrame(f *ackFrame, protected bool) error {
 	// Process aditional ACK Blocks
 	last := start
 	rawAckBlocks := f.AckBlockSection
-	assert(len(rawAckBlocks) == int(f.NumBlocks * 5)) //TODO manage non 32-bit ack blocks
+	assert(len(rawAckBlocks) == int(f.NumBlocks * 5)) //TODO(ekr@rtmf.com) manage non 32-bit ack blocks
 	for i := f.NumBlocks ; i > 0; i-- {
 		var decoded ackBlock
 		bytesread, err := decode(&decoded, rawAckBlocks)
@@ -1476,7 +1472,7 @@ func (c *Connection) processAckFrame(f *ackFrame, protected bool) error {
 		start = end - decoded.Length + 1
 
 		// This happens if a gap is larger than 255
-		if start > end {
+		if decoded.Length == 0 {
 			last -= uint64(decoded.Gap)
 			c.log(logTypeAck, "%s: encountered extra large ACK gap", c.label())
 			continue

--- a/connection.go
+++ b/connection.go
@@ -75,8 +75,8 @@ type ConnectionHandler interface {
 
 // Internal structures indicating ranges to ACK
 type ackRange struct {
-	lastPacket uint64	/* Packet with highest pn in range */
-	count      uint64	/* Total number of packets in range */
+	lastPacket uint64	// Packet with highest pn in range
+	count      uint64	// Total number of packets in range
 }
 
 type ackRanges []ackRange
@@ -395,7 +395,7 @@ func (c *Connection) determineAead(pt uint8) cipher.AEAD {
 
 func (c *Connection) sendPacketRaw(pt uint8, connId ConnectionId, pn uint64, version VersionNumber, payload []byte) error {
 	c.log(logTypeConnection, "Sending packet PT=%v PN=%x: %s", pt, c.nextSendPacket, dumpPacket(payload))
-	left := c.mtu /* track how much space is left for payload */
+	left := c.mtu // track how much space is left for payload
 
 	aead := c.determineAead(pt)
 	left -= aead.Overhead()
@@ -1456,11 +1456,11 @@ func (c *Connection) processAckFrame(f *ackFrame, protected bool) error {
 	end := f.LargestAcknowledged
 	start := end - f.AckBlockLength
 
-	/* Process the First ACK Block */
+	// Process the First ACK Block
 	c.log(logTypeAck, "%s: processing ACK range %x-%x", c.label(), start, end)
 	c.processAckRange(start, end, protected)
 
-	/* Process aditional ACK Blocks */
+	// Process aditional ACK Blocks
 	last := start
 	rawAckBlocks := f.AckBlockSection
 	assert(len(rawAckBlocks) == int(f.NumBlocks * 5)) //TODO manage non 32-bit ack blocks
@@ -1475,7 +1475,7 @@ func (c *Connection) processAckFrame(f *ackFrame, protected bool) error {
 		end = last - uint64(decoded.Gap) - 1
 		start = end - decoded.Length + 1
 
-		/* This happens if a gap is larger than 255 */
+		// This happens if a gap is larger than 255
 		if start > end {
 			last -= uint64(decoded.Gap)
 			c.log(logTypeAck, "%s: encountered extra large ACK gap", c.label())

--- a/frame.go
+++ b/frame.go
@@ -393,7 +393,7 @@ func (f ackFrame) TimestampSection__length() uintptr {
 func newAckFrame(rs ackRanges, maxackblocks uint8) (*frame, int, error) {
 	logf(logTypeFrame, "Making ACK frame %v", rs)
 
-	/* FIRST, fill in the basic info of the ACK frame */
+	// FIRST, fill in the basic info of the ACK frame
 	var f ackFrame
 	f.Type = kFrameTypeAck | 0xa
 	f.NumBlocks = 0
@@ -404,18 +404,18 @@ func newAckFrame(rs ackRanges, maxackblocks uint8) (*frame, int, error) {
 
 	addedRanges := 1
 
-	/* SECOND, add the remaining ACK blocks that fit and that we have */
+	// SECOND, add the remaining ACK blocks that fit and that we have
 	for (maxackblocks > f.NumBlocks) && (addedRanges < len(rs)) {
 
-		/* calculate blocks needed for the next range */
+		// calculate blocks needed for the next range
 		gap := last - rs[addedRanges].lastPacket - 1
 		blocksneeded := uint64((gap / maxAckGap) + 1)
 		if blocksneeded > uint64(maxackblocks) {
-			/* break if there is no space */
+			// break if there is no space
 			break
 		}
 
-		/* place the needed empty blocks */
+		// place the needed empty blocks
 		for i := uint64(0); i < blocksneeded - 1; i++ {
 			b := &ackBlock{
 				4, // Fixed 32-bit width (see 0xb above)
@@ -432,7 +432,7 @@ func newAckFrame(rs ackRanges, maxackblocks uint8) (*frame, int, error) {
 			f.AckBlockSection = append(f.AckBlockSection, encoded...)
 		}
 
-		/* Now place the actual block */
+		// Now place the actual block
 		gap = last - rs[addedRanges].lastPacket - 1
 		assert(gap < 256)
 		b := &ackBlock{

--- a/frame.go
+++ b/frame.go
@@ -406,10 +406,9 @@ func newAckFrame(rs ackRanges, maxackblocks uint8) (*frame, int, error) {
 
 	// SECOND, add the remaining ACK blocks that fit and that we have
 	for (maxackblocks > f.NumBlocks) && (addedRanges < len(rs)) {
-
 		// calculate blocks needed for the next range
 		gap := last - rs[addedRanges].lastPacket - 1
-		blocksneeded := uint64((gap / maxAckGap) + 1)
+		blocksneeded := uint64((gap + (maxAckGap - 1)) / maxAckGap)
 		if blocksneeded > uint64(maxackblocks) {
 			// break if there is no space
 			break

--- a/frame.go
+++ b/frame.go
@@ -35,7 +35,7 @@ const (
 
 type innerFrame interface {
 	getType() frameType
-// 	String() string
+ 	String() string
 }
 
 type frame struct {
@@ -384,10 +384,6 @@ func (f ackFrame) AckBlockLength__length() uintptr {
 
 func (f ackFrame) AckBlockSection__length() uintptr {
 	return uintptr(f.NumBlocks) * (1 + f.AckBlockLength__length())
-}
-
-func (f ackFrame) TimestampSection__length() uintptr {
-	return uintptr(f.NumTS * 5)
 }
 
 func newAckFrame(rs ackRanges, maxackblocks uint8) (*frame, int, error) {

--- a/frame.go
+++ b/frame.go
@@ -29,9 +29,13 @@ const (
 	kFrameTypeFlagD = frameType(0x01)
 )
 
+const (
+	maxAckGap = 255
+)
+
 type innerFrame interface {
 	getType() frameType
-	String() string
+// 	String() string
 }
 
 type frame struct {
@@ -382,39 +386,74 @@ func (f ackFrame) AckBlockSection__length() uintptr {
 	return uintptr(f.NumBlocks) * (1 + f.AckBlockLength__length())
 }
 
-func newAckFrame(rs ackRanges) (*frame, error) {
+func (f ackFrame) TimestampSection__length() uintptr {
+	return uintptr(f.NumTS * 5)
+}
+
+func newAckFrame(rs ackRanges, maxackblocks uint8) (*frame, int, error) {
 	logf(logTypeFrame, "Making ACK frame %v", rs)
 
+	/* FIRST, fill in the basic info of the ACK frame */
 	var f ackFrame
-
 	f.Type = kFrameTypeAck | 0xa
-	if len(rs) > 1 {
-		f.Type |= 0x10
-		f.NumBlocks = uint8(len(rs) - 1)
-	}
+	f.NumBlocks = 0
 	f.LargestAcknowledged = rs[0].lastPacket
 	f.AckBlockLength = rs[0].count - 1
 	last := f.LargestAcknowledged - f.AckBlockLength
 	f.AckDelay = 0
 
-	for i := 1; i < len(rs); i++ {
-		gap := last - rs[i].lastPacket
-		assert(gap < 256) // TODO(ekr@rtfm.com): handle this.
-		b := &ackBlock{
-			4, // Fixed 32-bit width (see 0xb above)
-			uint8(last - rs[i].lastPacket),
-			rs[i].count,
+	addedRanges := 1
+
+	/* SECOND, add the remaining ACK blocks that fit and that we have */
+	for (maxackblocks > f.NumBlocks) && (addedRanges < len(rs)) {
+
+		/* calculate blocks needed for the next range */
+		gap := last - rs[addedRanges].lastPacket - 1
+		blocksneeded := uint64((gap / maxAckGap) + 1)
+		if blocksneeded > uint64(maxackblocks) {
+			/* break if there is no space */
+			break
 		}
-		last = rs[i].lastPacket - rs[i].count + 1
+
+		/* place the needed empty blocks */
+		for i := uint64(0); i < blocksneeded - 1; i++ {
+			b := &ackBlock{
+				4, // Fixed 32-bit width (see 0xb above)
+				uint8(maxAckGap),
+				0,
+			}
+			last -= maxAckGap
+			encoded, err := encode(b)
+			if err != nil {
+				return nil, 0, err
+			}
+			f.Type |= 0x10
+			f.NumBlocks += 1
+			f.AckBlockSection = append(f.AckBlockSection, encoded...)
+		}
+
+		/* Now place the actual block */
+		gap = last - rs[addedRanges].lastPacket - 1
+		assert(gap < 256)
+		b := &ackBlock{
+			4,
+			uint8(gap),
+			rs[addedRanges].count,
+		}
+		last = rs[addedRanges].lastPacket - rs[addedRanges].count + 1
 		encoded, err := encode(b)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
+		f.Type |= 0x10
+		f.NumBlocks += 1
 		f.AckBlockSection = append(f.AckBlockSection, encoded...)
+
+		addedRanges += 1
 	}
 
 	ret := newFrame(0, &f)
-	return &ret, nil
+	return &ret, addedRanges, nil
 }
 
 // STREAM

--- a/frame_test.go
+++ b/frame_test.go
@@ -9,7 +9,7 @@ import (
 func TestAckFrameOneRange(t *testing.T) {
 	ar := []ackRange{{0xdeadbeef, 2}}
 
-	f, err := newAckFrame(ar)
+	f, _, err := newAckFrame(ar, 5)
 	assertNotError(t, err, "Couldn't make ack frame")
 
 	err = f.encode()
@@ -25,7 +25,7 @@ func TestAckFrameOneRange(t *testing.T) {
 func TestAckFrameTwoRanges(t *testing.T) {
 	ar := []ackRange{{0xdeadbeef, 2}, {0xdeadbee0, 1}}
 
-	f, err := newAckFrame(ar)
+	f, _, err := newAckFrame(ar, 10)
 	assertNotError(t, err, "Couldn't make ack frame")
 
 	err = f.encode()


### PR DESCRIPTION
Fixing some bugs in the ACK generating logic, and adding full ACK ranges support.

What it does:
* Support ACK ranges during ACK generation and processing
* Handle gaps larger than 255

What it does not do:
* Generate multiple ack frames when not everything fits into one ack frame