### PR TITLE
Solve superious packet bug

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1377,10 +1377,6 @@ func (c *Connection) newFrameData(s *Stream, inner *streamFrame) error {
 	}
 
 	s.newFrameData(inner.Offset, inner.hasFin(), inner.Data)
-// 	if s.newFrameData(inner.Offset, inner.hasFin(), inner.Data) && s.id > 0 &&
-// 		c.handler != nil {
-// 		c.handler.StreamReadable(s)
-// 	}
 
 	remaining := s.recv.maxStreamData - s.recv.lastReceivedByte()
 	c.log(logTypeFlowControl, "Stream %d has %d bytes of credit remaining, last byte received was", s.Id(), remaining, s.recv.lastReceivedByte())


### PR DESCRIPTION
This PR fixes the following behaviour:

Consider a client sending a `hello` packet to an echo server.

1. client sends `hello` to server on stream 1
1. Server starts processing packet frame by frame
1. Server processes `STREAM` frame with `hello` on stream 1
1. Server calls `StreamReadable(<stream 1>)`
1. Server application handles the `hello`, and sends an `echo`
1. Server transmits `echo` packet 
1. Server marks `hello` packet as received
1. Server transmits bare ack packet for `hello` packet

Commits:

* e1bdbd2: make sure packets is fully processed before a new packet is transmitted
* beb1d02: only flush queues if this has not already been caused by any of the `StreamReadable()` calls