### PR TITLE
ACK delay & RTT estimation

### DIFF
--- a/congestion.go
+++ b/congestion.go
@@ -82,7 +82,7 @@ type CongestionControllerIetf struct {
 	largestAckedPacket     uint64
 //	largestRtt             time.Duration
 	smoothedRtt            time.Duration
-	rttVar                 float32
+	rttVar                 time.Duration
 	reorderingThreshold    int
 	timeReorderingFraction float32
 	lossTime               time.Time
@@ -115,7 +115,7 @@ func (cc *CongestionControllerIetf) onPacketSent(pn uint64, isAckOnly bool, sent
 
 
 // acks is received to be a sorted list, where the largest packet numbers are at the beginning
-func(cc *CongestionControllerIetf) onAckReceived(acks ackRanges, delay time.Duration){
+func(cc *CongestionControllerIetf) onAckReceived(acks ackRanges, ackDelay time.Duration){
 
 	// keep track of largest packet acked overall
 	if acks[0].lastPacket > cc.largestAckedPacket {
@@ -125,11 +125,11 @@ func(cc *CongestionControllerIetf) onAckReceived(acks ackRanges, delay time.Dura
 	// If the largest acked is newly acked update rtt
 	_, present := cc.sentPackets[acks[0].lastPacket]
 	if present {
-		//TODO(ekr@rtfm.com) RTT stuff
-		//largestRtt = time.Now - cc.sentPackets[acks[0].lastPacket].txTime
-		//if (latestRtt > delay){
-		//	latestRtt -= delay
-		//	cc.updateRtt(latestRtt)
+		latestRtt := time.Since(cc.sentPackets[acks[0].lastPacket].txTime)
+		if (latestRtt > ackDelay){
+			latestRtt -= ackDelay
+			cc.updateRtt(latestRtt)
+		}
 	}
 
 	// find and proccess newly acked packets
@@ -154,7 +154,18 @@ func (cc *CongestionControllerIetf)	setLostPacketHandler(handler func(pn uint64)
 
 
 func(cc *CongestionControllerIetf) updateRtt(latestRtt time.Duration){
-	//TODO(ekr@rtfm.com)
+	if (cc.smoothedRtt == 0){
+		cc.smoothedRtt = latestRtt
+		cc.rttVar = time.Duration(int64(latestRtt) / 2)
+	} else {
+		rttDelta := cc.smoothedRtt - latestRtt;
+		if rttDelta < 0 {
+			rttDelta = -rttDelta
+		}
+		cc.rttVar = time.Duration(3/4 * int64(cc.rttVar) + 1/4 * int64(rttDelta))
+		cc.smoothedRtt = time.Duration(7/8 * int64(cc.smoothedRtt) + 1/8 * int64(latestRtt))
+	}
+	cc.conn.log(logTypeCongestion, "New RTT estimate: %v, variance: %v", cc.smoothedRtt, cc.rttVar)
 }
 
 func(cc *CongestionControllerIetf) onPacketAcked(pn uint64){

--- a/connection.go
+++ b/connection.go
@@ -593,7 +593,7 @@ func (c *Connection) sendOnStream(streamId uint32, data []byte) error {
 
 func (c *Connection) makeAckFrame(acks ackRanges, left int) (*frame, int, error) {
 	c.log(logTypeConnection, "Making ack frame, room=%d", left)
-	af, rangesSent, err := newAckFrame(acks, left)
+	af, rangesSent, err := newAckFrame(c.recvd, acks, left)
 	if err != nil {
 		c.log(logTypeConnection, "Couldn't prepare ACK frame %v", err)
 		return nil, 0, err

--- a/connection.go
+++ b/connection.go
@@ -1560,6 +1560,10 @@ func (c *Connection) processAckFrame(f *ackFrame, protected bool) error {
 	end := f.LargestAcknowledged
 	start := end - f.AckBlockLength
 
+	// Decode ACK Delay
+	ackDelayMicros := QuicFloat16(f.AckDelay).Float32()
+	ackDelay := time.Duration(ackDelayMicros * 1e3)
+
 	// Process the First ACK Block
 	c.log(logTypeAck, "%s: processing ACK range %x-%x", c.label(), start, end)
 	c.processAckRange(start, end, protected)
@@ -1593,7 +1597,7 @@ func (c *Connection) processAckFrame(f *ackFrame, protected bool) error {
 		receivedAcks = append(receivedAcks, ackRange{end, end - start + 1})
 	}
 
-	c.congestion.onAckReceived(receivedAcks, 0)
+	c.congestion.onAckReceived(receivedAcks, ackDelay)
 
 	return nil
 }

--- a/frame.go
+++ b/frame.go
@@ -393,7 +393,7 @@ func (f ackFrame) AckBlockSection__length() uintptr {
 }
 
 func newAckFrame(recvd *recvdPackets, rs ackRanges, left int) (*frame, int, error) {
-	if left < 16 {
+	if left < kAckHeaderLength {
 		return nil, 0, nil
 	}
 	logf(logTypeFrame, "Making ACK frame %v", rs)

--- a/frame_test.go
+++ b/frame_test.go
@@ -9,7 +9,11 @@ import (
 func TestAckFrameOneRange(t *testing.T) {
 	ar := []ackRange{{0xdeadbeef, 2}}
 
-	f, _, err := newAckFrame(ar, 21)
+	recvd := newRecvdPackets(logf)
+	recvd.init(ar[0].lastPacket)
+	recvd.packetSetReceived(ar[0].lastPacket, false, false)
+
+	f, _, err := newAckFrame(recvd, ar, 21)
 	assertNotError(t, err, "Couldn't make ack frame")
 
 	err = f.encode()
@@ -25,7 +29,11 @@ func TestAckFrameOneRange(t *testing.T) {
 func TestAckFrameTwoRanges(t *testing.T) {
 	ar := []ackRange{{0xdeadbeef, 2}, {0xdeadbee0, 1}}
 
-	f, _, err := newAckFrame(ar, 26)
+	recvd := newRecvdPackets(logf)
+	recvd.init(ar[0].lastPacket)
+	recvd.packetSetReceived(ar[0].lastPacket, false, false)
+
+	f, _, err := newAckFrame(recvd, ar, 26)
 	assertNotError(t, err, "Couldn't make ack frame")
 
 	err = f.encode()

--- a/quicfloat.go
+++ b/quicfloat.go
@@ -1,0 +1,51 @@
+/*
+ * Based of the "half" package. See https://github.com/h2so5/half
+ */
+
+package minq
+
+import "math"
+
+//TODO(ekr@rtfm.com) At the moment this is just a IEEE 754 float16
+
+// A QuicFloat16 represents a 16-bit floating point number.
+type QuicFloat16 uint16
+
+// NewQuicFloat16 allocates and returns a new Float16 set to f.
+func NewQuicFloat16(f float32) QuicFloat16 {
+	i := math.Float32bits(f)
+	sign := uint16((i >> 31) & 0x1)
+	exp := (i >> 23) & 0xff
+	exp16 := int16(exp) - 127 + 15
+	frac := uint16(i>>13) & 0x3ff
+	if exp == 0 {
+		exp16 = 0
+	} else if exp == 0xff {
+		exp16 = 0x1f
+	} else {
+		if exp16 > 0x1e {
+			exp16 = 0x1f
+			frac = 0
+		} else if exp16 < 0x01 {
+			exp16 = 0
+			frac = 0
+		}
+	}
+	f16 := (sign << 15) | uint16(exp16<<10) | frac
+	return QuicFloat16(f16)
+}
+
+// Float32 returns the float32 representation of f.
+func (f QuicFloat16) Float32() float32 {
+	sign := uint32((f >> 15) & 0x1)
+	exp := (f >> 10) & 0x1f
+	exp32 := uint32(exp) + 127 - 15
+	if exp == 0 {
+		exp32 = 0
+	} else if exp == 0x1f {
+		exp32 = 0xff
+	}
+	frac := uint32(f & 0x3ff)
+	i := (sign << 31) | (exp32 << 23) | (frac << 13)
+	return math.Float32frombits(i)
+}

--- a/quicfloat_test.go
+++ b/quicfloat_test.go
@@ -1,0 +1,46 @@
+/*
+ * Based of the "half" package. See https://github.com/h2so5/half
+ */
+
+package minq
+
+import (
+	"math"
+	"testing"
+)
+
+func getFloatTable() map[QuicFloat16]float32 {
+	table := map[QuicFloat16]float32{
+		0x3c00: 1,
+		0x4000: 2,
+		0xc000: -2,
+		0x7bfe: 65472,
+		0x7bff: 65504,
+		0xfbff: -65504,
+		0x0000: 0,
+		0x8000: float32(math.Copysign(0, -1)),
+		0x7c00: float32(math.Inf(1)),
+		0xfc00: float32(math.Inf(-1)),
+		0x5b8f: 241.875,
+		0x48c8: 9.5625,
+	}
+	return table
+}
+
+func TestFloat32(t *testing.T) {
+	for k, v := range getFloatTable() {
+		f := k.Float32()
+		if f != v {
+			t.Errorf("ToFloat32(%d) = %f, want %f.", k, f, v)
+		}
+	}
+}
+
+func TestNewQuicFloat16(t *testing.T) {
+	for k, v := range getFloatTable() {
+		i := NewQuicFloat16(v)
+		if i != k {
+			t.Errorf("FromFloat32(%f) = %d, want %d.", v, i, k)
+		}
+	}
+}


### PR DESCRIPTION
Adding RTT estimation to the congestion controller.

I added both QUIC and TCP-style estimates. The TCP style estimates do not consider the  `ACK Delay` field. They  might be useful later to see what the influence is of moving the stamping of the `ACK Delay` and the recording of the Rx time of packets.

For this I had to populate the `ACK Delay` field in ACK frames. I currently use the IEEE 754 binary16 half precision format to encode the time. This is not exactly the format from draft-ietf-quic-transport-07, but as that format is under review, implementing it seems a waste of time. I borrowed the code for this from https://github.com/h2so5/half, which is CC0.