### PR TITLE
Flow control

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1747,7 +1747,7 @@ func (c *Connection) setTransportParameters() {
 	// TODO(ekr@rtfm.com): Process the others..
 
 	// Cut stream 0 flow control down to something reasonable.
-	c.stream0.sendStreamPrivate.(*sendStream).maxStreamData = uint64(c.tpHandler.peerParams.maxStreamsData)
+	c.stream0.sendStreamPrivate.(*sendStream).fc.max = uint64(c.tpHandler.peerParams.maxStreamsData)
 
 	c.flowControl.update(uint64(c.tpHandler.peerParams.maxData))
 	c.localBidiStreams.nstreams = c.tpHandler.peerParams.maxStreamsBidi

--- a/connection_test.go
+++ b/connection_test.go
@@ -889,11 +889,6 @@ func fillConnectionCongestionWindow(c *Connection) ([]SendStream, []int, []byte)
 		cstreams[i] = s
 		var err error
 		for err == nil {
-			// This is a truly messed up compiler bug.  You can't use
-			//     n, err := s.Write(writeBuf)
-			// because go will assume that you want a new `err`, but
-			// that isn't used.  In other words, it chooses name
-			// shadowing over reuse here.
 			var n int
 			n, err = s.Write(writeBuf)
 			outstanding[i] += n
@@ -929,6 +924,8 @@ func TestConnectionLevelFlowControl(t *testing.T) {
 	pair.server.sendQueued(false)
 	inputAll(pair.client)
 
+	assertX(t, (uint64(kConcurrentStreamsUni-1)*kInitialMaxStreamData) > kInitialMaxData,
+		"should be able to fill connection flow control without using the last stream")
 	// Use the last stream, which shouldn't have written anything.
 	last := len(outstanding) - 1
 	assertEquals(t, outstanding[last], 0)

--- a/errors.go
+++ b/errors.go
@@ -93,6 +93,7 @@ var ErrorMissingValue = fatalError("Expected value is missing")
 var ErrorInvalidEncoding = fatalError("Invalid encoding")
 var ErrorProtocolViolation = fatalError("Protocol violation")
 var ErrorFrameFormatError = fatalError("Frame format error")
+var ErrorFlowControlError = fatalError("Flow control error")
 
 // Protocol errors
 type ErrorCode uint16

--- a/frame.go
+++ b/frame.go
@@ -325,6 +325,10 @@ func (f blockedFrame) getType() frameType {
 	return kFrameTypeBlocked
 }
 
+func newBlockedFrame(offset uint64) frame {
+	return newFrame(0, &blockedFrame{kFrameTypeBlocked, offset})
+}
+
 // STREAM_BLOCKED
 type streamBlockedFrame struct {
 	Type     frameType
@@ -338,6 +342,10 @@ func (f streamBlockedFrame) String() string {
 
 func (f streamBlockedFrame) getType() frameType {
 	return kFrameTypeStreamBlocked
+}
+
+func newStreamBlockedFrame(id uint64, offset uint64) frame {
+	return newFrame(0, &streamBlockedFrame{kFrameTypeStreamBlocked, id, offset})
 }
 
 // STREAM_ID_BLOCKED

--- a/frame.go
+++ b/frame.go
@@ -247,6 +247,10 @@ func (f maxDataFrame) getType() frameType {
 	return kFrameTypeMaxData
 }
 
+func newMaxData(m uint64) frame {
+	return newFrame(0, &maxDataFrame{kFrameTypeMaxData, m})
+}
+
 // MAX_STREAM_DATA
 type maxStreamDataFrame struct {
 	Type              frameType

--- a/stream_test.go
+++ b/stream_test.go
@@ -47,12 +47,13 @@ func newTestStreamFixture(t *testing.T) *testStreamFixture {
 		logf(tag, fullFormat, args...)
 	}
 
+	fc := flowControl{2048, 0}
 	return &testStreamFixture{
 		t:    t,
 		name: name,
 		log:  log,
-		r:    &recvStreamBase{streamCommon: streamCommon{log: log, maxStreamData: 2048}},
-		w:    &sendStreamBase{streamCommon: streamCommon{log: log, maxStreamData: 2048}},
+		r:    &recvStreamBase{streamCommon: streamCommon{log: log, fc: fc}},
+		w:    &sendStreamBase{streamCommon: streamCommon{log: log, fc: fc}},
 		b:    nil,
 	}
 }
@@ -154,7 +155,7 @@ func TestStreamIncreaseFlowControl(t *testing.T) {
 	f := newTestStreamFixture(t)
 	f.w.processMaxStreamData(2050)
 	f.w.processMaxStreamData(2000)
-	assertEquals(t, uint64(2050), f.w.maxStreamData)
+	assertEquals(t, uint64(2050), f.w.fc.max)
 }
 
 func countChunkLens(chunks []streamChunk) int {

--- a/transport_parameters.go
+++ b/transport_parameters.go
@@ -274,14 +274,17 @@ func (h *transportParametersHandler) Receive(hs mint.HandshakeType, el *mint.Ext
 	// TODO(ekr@rtfm.com): Enforce that each param appears only once.
 	var tp transportParameters
 	h.log(logTypeHandshake, "Reading transport parameters values")
+
 	tp.maxStreamsData, err = params.getUintParameter(kTpIdInitialMaxStreamsData, 4)
 	if err != nil {
 		return err
 	}
+
 	tp.maxData, err = params.getUintParameter(kTpIdInitialMaxData, 4)
 	if err != nil {
 		return err
 	}
+
 	maxStream, err := params.getUintParameter(kTpIdInitialMaxStreamIdBidi, 4)
 	if err == ErrorMissingValue {
 		maxStream = 0
@@ -293,6 +296,7 @@ func (h *transportParametersHandler) Receive(hs mint.HandshakeType, el *mint.Ext
 			return ErrorInvalidEncoding
 		}
 	}
+
 	tp.maxStreamsBidi = (int(maxStream) >> 2) + 1
 	maxStream, err = params.getUintParameter(kTpIdInitialMaxStreamIdUni, 4)
 	if err == ErrorMissingValue {
@@ -305,6 +309,7 @@ func (h *transportParametersHandler) Receive(hs mint.HandshakeType, el *mint.Ext
 			return ErrorInvalidEncoding
 		}
 	}
+
 	tp.maxStreamsUni = (int(maxStream) >> 2) + 1
 	var tmp uint32
 	tmp, err = params.getUintParameter(kTpIdIdleTimeout, 2)


### PR DESCRIPTION
This implements connection-level flow control.  I found a few structural issues with other parts of the code (my previous changes primarily).

This includes back pressure on write.  Write returns ErrorWouldBlock if there is no available flow control credit.

This adds sending of [STREAM_]BLOCKED frames when various things run out.  It stops sending them as appropriate.