### PR TITLE
Packet header changes for -11

### DIFF
--- a/bin/server/main.go
+++ b/bin/server/main.go
@@ -44,7 +44,7 @@ func (c *conn) checkTimer() {
 	}
 }
 
-var conns = make(map[minq.ConnectionId]*conn)
+var conns = make(map[string]*conn)
 
 // An feed through server.
 type feedthroughServerHandler struct {
@@ -54,7 +54,7 @@ type feedthroughServerHandler struct {
 func (h *feedthroughServerHandler) NewConnection(c *minq.Connection) {
 	log.Println("New connection")
 	c.SetHandler(&feedthroughConnHandler{echo, 0})
-	conns[c.Id()] = &conn{c, time.Now()}
+	conns[c.ServerId().String()] = &conn{c, time.Now()}
 }
 
 type feedthroughConnHandler struct {
@@ -98,7 +98,7 @@ func (h *feedthroughConnHandler) StreamReadable(s minq.RecvStream) {
 
 		if echo {
 			// Flip the case so we can distinguish echo
-			for i, _ := range b {
+			for i := range b {
 				if b[i] > 0x40 {
 					b[i] ^= 0x20
 				}
@@ -116,7 +116,7 @@ type httpServerHandler struct {
 func (h *httpServerHandler) NewConnection(c *minq.Connection) {
 	log.Println("New connection")
 	c.SetHandler(&httpConnHandler{make(map[uint64]*httpStream, 0)})
-	conns[c.Id()] = &conn{c, time.Now()}
+	conns[c.ServerId().String()] = &conn{c, time.Now()}
 }
 
 type httpStream struct {

--- a/connection.go
+++ b/connection.go
@@ -297,6 +297,16 @@ func (state State) String() string {
 	}
 }
 
+// ClientId returns the current identity, as dictated by the client.
+func (c *Connection) ClientId() ConnectionId {
+	return c.clientConnectionId
+}
+
+// ServerId returns the current identity, as dictated by the server.
+func (c *Connection) ServerId() ConnectionId {
+	return c.serverConnectionId
+}
+
 func (c *Connection) ensureRemoteBidi(id uint64) hasIdentity {
 	return c.remoteBidiStreams.ensure(id, func(x uint64) hasIdentity {
 		msd := uint64(c.tpHandler.peerParams.maxStreamsData)

--- a/connection.go
+++ b/connection.go
@@ -450,7 +450,7 @@ func (c *Connection) determineAead(pt packetType) cipher.AEAD {
 	return aead
 }
 
-func (c *Connection) sendPacketRaw(pt packetType, connId ConnectionId, pn uint64, version VersionNumber, payload []byte, containsOnlyAcks bool) ([]byte, error) {
+func (c *Connection) sendPacketRaw(pt packetType, version VersionNumber, pn uint64, payload []byte, containsOnlyAcks bool) ([]byte, error) {
 	c.log(logTypeConnection, "Sending packet PT=%v PN=%x: %s", pt, pn, dumpPacket(payload))
 	left := c.mtu // track how much space is left for payload
 

--- a/connection.go
+++ b/connection.go
@@ -12,6 +12,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"time"
 
@@ -45,7 +46,7 @@ const (
 
 const (
 	kMinimumClientInitialLength  = 1200 // draft-ietf-quic-transport S 9.0
-	kLongHeaderLength            = 17
+	kLongHeaderLength            = 12   // omits connection ID lengths
 	kInitialIntegrityCheckLength = 16   // Overhead.
 	kInitialMTU                  = 1252 // 1280 - UDP headers.
 )
@@ -54,14 +55,14 @@ const (
 type VersionNumber uint32
 
 const (
-	kQuicDraftVersion   = 9
+	kQuicDraftVersion   = 11
 	kQuicVersion        = VersionNumber(0xff000000 | kQuicDraftVersion)
 	kQuicGreaseVersion1 = VersionNumber(0x1a1a1a1a)
 	kQuicGreaseVersion2 = VersionNumber(0x2a2a2a2a)
 )
 
 const (
-	kQuicALPNToken = "hq-09"
+	kQuicALPNToken = "hq-11"
 )
 
 // Interface for the handler object which the Connection will call
@@ -107,80 +108,82 @@ The application provides a handler object which the Connection
 calls to notify it of various events.
 */
 type Connection struct {
-	handler            ConnectionHandler
-	role               Role
-	state              State
-	version            VersionNumber
-	clientConnId       ConnectionId
-	serverConnId       ConnectionId
-	transport          Transport
-	tls                *tlsConn
-	writeClear         *cryptoState
-	readClear          *cryptoState
-	writeProtected     *cryptoState
-	readProtected      *cryptoState
-	nextSendPacket     uint64
-	mtu                int
-	stream0            *stream
-	localBidiStreams   *streamSet
-	remoteBidiStreams  *streamSet
-	localUniStreams    *streamSet
-	remoteUniStreams   *streamSet
-	outputClearQ       []frame // For stream 0
-	outputProtectedQ   []frame // For stream >= 0
-	clientInitial      []byte
-	recvd              *recvdPackets
-	flowControl        flowControl
-	sentAcks           map[uint64]ackRanges
-	lastInput          time.Time
-	idleTimeout        time.Duration
-	tpHandler          *transportParametersHandler
-	log                loggingFunction
-	retransmitTime     time.Duration
-	congestion         CongestionController
-	lastSendQueuedTime time.Time
-	closingEnd         time.Time
-	closePacket        []byte
+	handler             ConnectionHandler
+	role                Role
+	state               State
+	version             VersionNumber
+	initialConnectionId ConnectionId
+	clientConnectionId  ConnectionId
+	serverConnectionId  ConnectionId
+	transport           Transport
+	tls                 *tlsConn
+	writeClear          *cryptoState
+	readClear           *cryptoState
+	writeProtected      *cryptoState
+	readProtected       *cryptoState
+	nextSendPacket      uint64
+	mtu                 int
+	stream0             *stream
+	localBidiStreams    *streamSet
+	remoteBidiStreams   *streamSet
+	localUniStreams     *streamSet
+	remoteUniStreams    *streamSet
+	outputClearQ        []frame // For stream 0
+	outputProtectedQ    []frame // For stream >= 0
+	clientInitial       []byte
+	recvd               *recvdPackets
+	flowControl         flowControl
+	sentAcks            map[uint64]ackRanges
+	lastInput           time.Time
+	idleTimeout         time.Duration
+	tpHandler           *transportParametersHandler
+	log                 loggingFunction
+	retransmitTime      time.Duration
+	congestion          CongestionController
+	lastSendQueuedTime  time.Time
+	closingEnd          time.Time
+	closePacket         []byte
 }
 
 // Create a new QUIC connection. Should only be used with role=RoleClient,
 // though we use it with RoleServer internally.
 func NewConnection(trans Transport, role Role, tls *TlsConfig, handler ConnectionHandler) *Connection {
 	c := &Connection{
-		handler:            handler,
-		role:               role,
-		state:              StateInit,
-		version:            kQuicVersion,
-		clientConnId:       0,
-		serverConnId:       0,
-		transport:          trans,
-		tls:                newTlsConn(tls, role),
-		writeClear:         nil,
-		readClear:          nil,
-		writeProtected:     nil,
-		readProtected:      nil,
-		nextSendPacket:     uint64(0),
-		mtu:                kInitialMTU,
-		stream0:            nil,
-		localBidiStreams:   newStreamSet(streamTypeBidirectionalLocal, role, 1),
-		remoteBidiStreams:  newStreamSet(streamTypeBidirectionalRemote, role, kConcurrentStreamsBidi),
-		localUniStreams:    newStreamSet(streamTypeUnidirectionalLocal, role, 0),
-		remoteUniStreams:   newStreamSet(streamTypeUnidirectionalRemote, role, kConcurrentStreamsUni),
-		outputClearQ:       nil,
-		outputProtectedQ:   nil,
-		clientInitial:      nil,
-		recvd:              nil,
-		flowControl:        flowControl{0, 0},
-		sentAcks:           make(map[uint64]ackRanges, 0),
-		lastInput:          time.Now(),
-		idleTimeout:        time.Second * 5, // a pretty short time
-		tpHandler:          nil,
-		log:                nil,
-		retransmitTime:     kDefaultInitialRtt,
-		congestion:         nil,
-		lastSendQueuedTime: time.Now(),
-		closingEnd:         time.Time{}, // Zero time
-		closePacket:        nil,
+		handler:             handler,
+		role:                role,
+		state:               StateInit,
+		version:             kQuicVersion,
+		initialConnectionId: nil,
+		clientConnectionId:  nil,
+		serverConnectionId:  nil,
+		transport:           trans,
+		tls:                 newTlsConn(tls, role),
+		writeClear:          nil,
+		readClear:           nil,
+		writeProtected:      nil,
+		readProtected:       nil,
+		nextSendPacket:      uint64(0),
+		mtu:                 kInitialMTU,
+		stream0:             nil,
+		localBidiStreams:    newStreamSet(streamTypeBidirectionalLocal, role, 1),
+		remoteBidiStreams:   newStreamSet(streamTypeBidirectionalRemote, role, kConcurrentStreamsBidi),
+		localUniStreams:     newStreamSet(streamTypeUnidirectionalLocal, role, 0),
+		remoteUniStreams:    newStreamSet(streamTypeUnidirectionalRemote, role, kConcurrentStreamsUni),
+		outputClearQ:        nil,
+		outputProtectedQ:    nil,
+		clientInitial:       nil,
+		recvd:               nil,
+		flowControl:         flowControl{0, 0},
+		sentAcks:            make(map[uint64]ackRanges, 0),
+		lastInput:           time.Now(),
+		idleTimeout:         time.Second * 5, // a pretty short time
+		tpHandler:           nil,
+		log:                 nil,
+		retransmitTime:      kDefaultInitialRtt,
+		congestion:          nil,
+		lastSendQueuedTime:  time.Now(),
+		closingEnd:          time.Time{}, // Zero time
+		closePacket:         nil,
 	}
 
 	c.log = newConnectionLogger(c)
@@ -195,38 +198,40 @@ func NewConnection(trans Transport, role Role, tls *TlsConfig, handler Connectio
 	c.tls.setTransportParametersHandler(c.tpHandler)
 
 	c.recvd = newRecvdPackets(c.log)
-	tmp, err := generateRand64()
+	cid, err := c.randomConnectionId(8) // TODO configure this
 	if err != nil {
 		return nil
 	}
-	cid := ConnectionId(tmp)
 	var clientStreams *streamSet
 	if role == RoleClient {
-		c.clientConnId = cid
+		c.initialConnectionId, err = c.randomConnectionId(8)
+		if err != nil {
+			return nil
+		}
+		c.clientConnectionId = cid
 		err = c.setupAeadMasking()
 		if err != nil {
 			return nil
 		}
 		clientStreams = c.localBidiStreams
 	} else {
-		c.serverConnId = cid
+		c.serverConnectionId = cid
 		c.setState(StateWaitClientInitial)
 		clientStreams = c.remoteBidiStreams
 	}
 	c.stream0 = newStream(c, 0, ^uint64(0), ^uint64(0)).(*stream)
 	clientStreams.streams = append(clientStreams.streams, c.stream0)
 
-	tmp, err = generateRand64()
+	err = c.randomPacketNumber()
 	if err != nil {
 		return nil
 	}
-	c.nextSendPacket = tmp & 0x7fffffff
 
 	return c
 }
 
 func (c *Connection) String() string {
-	return fmt.Sprintf("Conn: %.16x:%.16x: %s", c.clientConnId, c.serverConnId, c.role)
+	return fmt.Sprintf("Conn: %v_%v: %s", c.clientConnectionId, c.serverConnectionId, c.role)
 }
 
 func (c *Connection) zeroRttAllowed() bool {
@@ -401,7 +406,7 @@ func (c *Connection) sendClientInitial() error {
 	   attacks caused by server responses toward an unverified client
 	   address.
 	*/
-	topad := kMinimumClientInitialLength - (kLongHeaderLength + l + kInitialIntegrityCheckLength)
+	topad := kMinimumClientInitialLength - (l + c.packetOverhead(packetTypeInitial))
 	c.log(logTypeHandshake, "Padding with %d padding frames", topad)
 
 	// Enqueue the frame for transmission.
@@ -419,29 +424,7 @@ func (c *Connection) sendClientInitial() error {
 	return err
 }
 
-func (c *Connection) sendSpecialClearPacket(pt uint8, connId ConnectionId, pn uint64, version VersionNumber, payload []byte) error {
-	c.log(logTypeConnection, "Sending special clear packet type=%v", pt)
-	p := packet{
-		packetHeader{
-			pt | packetFlagLongHeader,
-			connId,
-			version,
-			pn,
-		},
-		payload,
-	}
-
-	packet, err := encode(&p.packetHeader)
-	if err != nil {
-		return err
-	}
-	packet = append(packet, payload...)
-	c.congestion.onPacketSent(pn, false, len(packet)) //TODO(piet@devae.re) check isackonly
-	c.transport.Send(packet)
-	return nil
-}
-
-func (c *Connection) determineAead(pt uint8) cipher.AEAD {
+func (c *Connection) determineAead(pt packetType) cipher.AEAD {
 	var aead cipher.AEAD
 	if c.writeProtected != nil {
 		aead = c.writeProtected.aead
@@ -465,28 +448,29 @@ func (c *Connection) determineAead(pt uint8) cipher.AEAD {
 	return aead
 }
 
-func (c *Connection) sendPacketRaw(pt uint8, connId ConnectionId, pn uint64, version VersionNumber, payload []byte, containsOnlyAcks bool) ([]byte, error) {
+func (c *Connection) sendPacketRaw(pt packetType, connId ConnectionId, pn uint64, version VersionNumber, payload []byte, containsOnlyAcks bool) ([]byte, error) {
 	c.log(logTypeConnection, "Sending packet PT=%v PN=%x: %s", pt, pn, dumpPacket(payload))
 	left := c.mtu // track how much space is left for payload
 
 	aead := c.determineAead(pt)
 	left -= aead.Overhead()
 
-	if pt == packetTypeProtectedShort {
-		pt = 0x1d
+	var destCid ConnectionId
+	var srcCid ConnectionId
+	if c.role == RoleClient {
+		if c.serverConnectionId != nil {
+			destCid = c.serverConnectionId
+		} else {
+			destCid = c.initialConnectionId
+		}
+		srcCid = c.clientConnectionId
 	} else {
-		pt = pt | packetFlagLongHeader
+		srcCid = c.serverConnectionId
+		destCid = c.clientConnectionId
 	}
-	p := packet{
-		packetHeader{
-			pt,
-			connId,
-			version,
-			pn,
-		},
-		nil,
-	}
-	c.logPacket("Sent", &p.packetHeader, pn, payload)
+
+	p := newPacket(pt, destCid, srcCid, version, pn, payload)
+	c.logPacket("Sending", &p.packetHeader, pn, payload)
 
 	// Encode the header so we know how long it is.
 	// TODO(ekr@rtfm.com): this is gross.
@@ -514,7 +498,7 @@ func (c *Connection) sendPacketNow(tosend []frame, containsOnlyAcks bool) ([]byt
 }
 
 // Send a packet with a specific PT.
-func (c *Connection) sendPacket(pt uint8, tosend []frame, containsOnlyAcks bool) ([]byte, error) {
+func (c *Connection) sendPacket(pt packetType, tosend []frame, containsOnlyAcks bool) ([]byte, error) {
 	sent := 0
 
 	payload := make([]byte, 0)
@@ -538,106 +522,10 @@ func (c *Connection) sendPacket(pt uint8, tosend []frame, containsOnlyAcks bool)
 		sent++
 	}
 
-	connId := c.serverConnId
-	if c.role == RoleClient {
-		if pt == packetTypeInitial {
-			connId = c.clientConnId
-		}
-	} else {
-		if pt == packetTypeRetry {
-			connId = c.clientConnId
-		}
-	}
-
 	pn := c.nextSendPacket
 	c.nextSendPacket++
 
-	return c.sendPacketRaw(pt, connId, pn, c.version, payload, containsOnlyAcks)
-}
-
-func (c *Connection) sendFramesInPacket(pt uint8, tosend []frame) error {
-	c.log(logTypeConnection, "%s: Sending packet of type %v. %v frames", c.role, pt, len(tosend))
-	c.log(logTypeTrace, "Sending packet of type %v. %v frames", pt, len(tosend))
-	left := c.mtu
-
-	var connId ConnectionId
-	var aead cipher.AEAD
-	if c.writeProtected != nil {
-		aead = c.writeProtected.aead
-	}
-	connId = c.serverConnId
-
-	longHeader := true
-	if c.role == RoleClient {
-		switch {
-		case pt == packetTypeInitial:
-			aead = c.writeClear.aead
-			connId = c.clientConnId
-		case pt == packetTypeHandshake:
-			aead = c.writeClear.aead
-		case pt == packetType0RTTProtected:
-			connId = c.clientConnId
-			aead = nil // This will cause a crash b/c 0-RTT doesn't work yet
-		default:
-			longHeader = false
-		}
-	} else {
-		if pt == packetTypeHandshake {
-			aead = c.writeClear.aead
-		} else {
-			longHeader = true
-		}
-	}
-
-	left -= aead.Overhead()
-
-	npt := pt
-	if longHeader {
-		npt |= packetFlagLongHeader
-	}
-	pn := c.nextSendPacket
-	p := packet{
-		packetHeader{
-			npt,
-			connId,
-			c.version,
-			pn,
-		},
-		nil,
-	}
-	c.nextSendPacket++
-
-	// Encode the header so we know how long it is.
-	// TODO(ekr@rtfm.com): this is gross.
-	hdr, err := encode(&p.packetHeader)
-	if err != nil {
-		return err
-	}
-	left -= len(hdr)
-
-	sent := 0
-
-	for _, f := range tosend {
-		l, err := f.length()
-		if err != nil {
-			return err
-		}
-
-		assert(l <= left)
-
-		c.log(logTypeTrace, "Frame=%v", hex.EncodeToString(f.encoded))
-		p.payload = append(p.payload, f.encoded...)
-		sent++
-	}
-
-	protected := aead.Seal(nil, c.packetNonce(p.PacketNumber), p.payload, hdr)
-	packet := append(hdr, protected...)
-
-	c.log(logTypeTrace, "Sending packet len=%d, len=%v", len(packet), hex.EncodeToString(packet))
-	c.congestion.onPacketSent(pn, false, len(packet)) //TODO(piet@devae.re) check isackonly
-	c.transport.Send(packet)
-
-	return nil
+	return c.sendPacketRaw(pt, c.version, pn, payload, containsOnlyAcks)
 }
 
 func (c *Connection) sendOnStream0(data []byte) error {
@@ -710,7 +598,7 @@ func (c *Connection) sendQueued(bareAcks bool) (int, error) {
 }
 
 // Send a packet of stream frames, plus whatever acks fit.
-func (c *Connection) sendCombinedPacket(pt uint8, frames []frame, acks ackRanges, left int) (int, error) {
+func (c *Connection) sendCombinedPacket(pt packetType, frames []frame, acks ackRanges, left int) (int, error) {
 	asent := int(0)
 	var err error
 
@@ -780,16 +668,39 @@ func (c *Connection) sendFrame(f frame) error {
 	return err
 }
 
+func (c *Connection) packetOverhead(pt packetType) int {
+	overhead := c.determineAead(pt).Overhead()
+	if pt.isLongHeader() {
+		overhead += kLongHeaderLength
+		if c.role == RoleClient {
+			overhead += len(c.clientConnectionId)
+		} else {
+			overhead += len(c.serverConnectionId)
+		}
+	} else {
+		overhead += 5
+	}
+	if c.role == RoleClient {
+		if c.serverConnectionId == nil {
+			overhead += len(c.initialConnectionId)
+		} else {
+			overhead += len(c.serverConnectionId)
+		}
+	} else {
+		overhead += len(c.clientConnectionId)
+	}
+	return overhead
+}
+
 /* Transmit all the frames permitted by connection level flow control and
 * the congestion controller. We're going to need to be more sophisticated
 * when we actually do connection level flow control. */
-func (c *Connection) sendQueuedFrames(pt uint8, protected bool, bareAcks bool) (int, error) {
+func (c *Connection) sendQueuedFrames(pt packetType, protected bool, bareAcks bool) (int, error) {
 	c.log(logTypeConnection, "sendQueuedFrames, pt=%v, protected=%v", pt, protected)
 
 	acks := c.recvd.prepareAckRange(protected, false)
 	now := time.Now()
 	txAge := c.retransmitTime * time.Millisecond
-	aeadOverhead := c.determineAead(pt).Overhead()
 	sent := int(0)
 	spaceInCongestionWindow := c.congestion.bytesAllowedToSend()
 
@@ -809,9 +720,10 @@ func (c *Connection) sendQueuedFrames(pt uint8, protected bool, bareAcks bool) (
 
 	// Store frames that will be sent in the next packet
 	frames := make([]frame, 0)
-	// The length of the next packet to be send
-	spaceInPacket := c.mtu - aeadOverhead - kLongHeaderLength // TODO(ekr@rtfm.com): check header type
-	spaceInCongestionWindow -= (aeadOverhead + kLongHeaderLength)
+	// Calculate available space in the next packet.
+	overhead := c.packetOverhead(pt)
+	spaceInPacket := c.mtu - overhead
+	spaceInCongestionWindow -= overhead
 
 	for i := range *queue {
 		f := &((*queue)[i])
@@ -851,8 +763,8 @@ func (c *Connection) sendQueuedFrames(pt uint8, protected bool, bareAcks bool) (
 
 			acks = acks[asent:]
 			frames = make([]frame, 0)
-			spaceInPacket = c.mtu - aeadOverhead - kLongHeaderLength // TODO(ekr@rtfm.com): check header type
-			spaceInCongestionWindow -= (aeadOverhead + kLongHeaderLength)
+			spaceInPacket = c.mtu - overhead
+			spaceInCongestionWindow -= overhead
 		}
 
 		// add the frame to the packet
@@ -965,7 +877,7 @@ func (c *Connection) input(p []byte) error {
 
 	c.lastInput = time.Now()
 
-	var hdr packetHeader
+	hdr := packetHeader{shortCidLength: 8}
 
 	c.log(logTypeTrace, "Receiving packet len=%v %v", len(p), hex.EncodeToString(p))
 	hdrlen, err := decode(&hdr, p)
@@ -975,10 +887,10 @@ func (c *Connection) input(p []byte) error {
 	}
 	assert(int(hdrlen) <= len(p))
 
-	if isLongHeader(&hdr) && hdr.Version != c.version {
+	if hdr.Type.isLongHeader() && hdr.Version != c.version {
 		if c.role == RoleServer {
 			c.log(logTypeConnection, "Received unsupported version %v, expected %v", hdr.Version, c.version)
-			err = c.sendVersionNegotiation(hdr.ConnectionID, hdr.PacketNumber, hdr.Version)
+			err = c.sendVersionNegotiation(hdr)
 			if err != nil {
 				return err
 			}
@@ -999,18 +911,17 @@ func (c *Connection) input(p []byte) error {
 	c.log(logTypeFlowControl, "EKR: Received packet %x len=%d", hdr.PacketNumber, len(p))
 	c.log(logTypeConnection, "Packet header %v, %d", hdr, typ)
 
-	if isLongHeader(&hdr) && hdr.Version == 0 {
+	if hdr.Type.isLongHeader() && hdr.Version == 0 {
 		return c.processVersionNegotiation(&hdr, p[hdrlen:])
 	}
 
 	if c.state == StateWaitClientInitial {
 		if typ != packetTypeInitial {
 			c.log(logTypeConnection, "Received unexpected packet before client initial")
-			return nil
+			return ErrorDestroyConnection
 		}
-		// TODO(ekr@rtfm.com): This will result in connection ID flap if we
-		// receive a new connection from the same tuple with a different conn ID.
-		c.clientConnId = hdr.ConnectionID
+		c.initialConnectionId = hdr.DestinationConnectionID
+		c.clientConnectionId = hdr.SourceConnectionID
 		err := c.setupAeadMasking()
 		if err != nil {
 			return err
@@ -1018,7 +929,7 @@ func (c *Connection) input(p []byte) error {
 	}
 
 	aead := c.readClear.aead
-	if hdr.isProtected() {
+	if hdr.Type.isProtected() {
 		if c.readProtected == nil {
 			c.log(logTypeConnection, "Received protected data before crypto state is ready")
 			return nil
@@ -1076,7 +987,7 @@ func (c *Connection) input(p []byte) error {
 		c.log(logTypeConnection, "Unsupported packet type %v", typ)
 		err = internalError("Unsupported packet type %v", typ)
 	}
-	c.recvd.packetSetReceived(packetNumber, hdr.isProtected(), naf)
+	c.recvd.packetSetReceived(packetNumber, hdr.Type.isProtected(), naf)
 	if err != nil {
 		return err
 	}
@@ -1166,7 +1077,7 @@ func (c *Connection) processClientInitial(hdr *packetHeader, payload []byte) err
 		if err != nil {
 			return err
 		}
-		_, err = c.sendPacketRaw(packetTypeRetry, hdr.ConnectionID, hdr.PacketNumber, kQuicVersion, sf.encoded, false)
+		_, err = c.sendPacketRaw(packetTypeRetry, kQuicVersion, hdr.PacketNumber, sf.encoded, false)
 		return err
 	}
 
@@ -1236,12 +1147,15 @@ func (c *Connection) processCleartext(hdr *packetHeader, payload []byte, naf *bo
 				//
 				// 1. Remove the clientInitial packet.
 				// 2. Set the outgoing stream offset accordingly
-				// 3. Remember the connection ID
 				if len(c.clientInitial) > 0 {
 					c.stream0.sendStreamPrivate.(*sendStream).offset = uint64(len(c.clientInitial))
 					c.clientInitial = nil
-					c.serverConnId = hdr.ConnectionID
 				}
+				// Set the server's connection ID now.
+				// TODO: don't let the server change its mind.  This is complicated
+				// because each flight is multiple packets, and Handshake and Retry
+				// packets can each set a different value.
+				c.serverConnectionId = hdr.SourceConnectionID
 			} else {
 				if c.state != StateWaitClientSecondFlight {
 					// TODO(ekr@rtfm.com): Not clear what to do here. It's
@@ -1316,23 +1230,42 @@ func (c *Connection) processCleartext(hdr *packetHeader, payload []byte, naf *bo
 	return nil
 }
 
-func (c *Connection) sendVersionNegotiation(connId ConnectionId, pn uint64, version VersionNumber) error {
-	p := newVersionNegotiationPacket([]VersionNumber{
+func (c *Connection) sendVersionNegotiation(hdr packetHeader) error {
+	vn := newVersionNegotiationPacket([]VersionNumber{
 		c.version,
 		kQuicGreaseVersion1,
 	})
-	b, err := encode(p)
+	payload, err := encode(vn)
 	if err != nil {
 		return err
+	}
+	if hdr.PayloadLength < uint64(len(payload)) {
+		// The received packet was far to small to be considered valid.
+		// Just drop it without sending anything.
+		return nil
 	}
 
 	// Generate a random packet type.
-	pt, err := generateRand64()
+	pt := []byte{0}
+	_, err = rand.Read(pt)
 	if err != nil {
 		return err
 	}
 
-	return c.sendSpecialClearPacket(uint8((pt&0x7f)|packetFlagLongHeader), connId, pn, 0, b)
+	c.log(logTypeConnection, "Sending version negotiation packet")
+	p := newPacket(packetType(pt[0]&0x7f), hdr.SourceConnectionID, hdr.DestinationConnectionID,
+		0, hdr.PacketNumber, payload)
+
+	header, err := encode(&p.packetHeader)
+	if err != nil {
+		return err
+	}
+	packet := append(header, payload...)
+	// Note that we do not update the congestion controller for this packet.
+	// This connection is about to disappear anyway.  Our defense against being
+	// used as an amplifier is the size check above.
+	c.transport.Send(packet)
+	return nil
 }
 
 func (c *Connection) processVersionNegotiation(hdr *packetHeader, payload []byte) error {
@@ -1771,12 +1704,11 @@ func (c *Connection) setupAeadMasking() (err error) {
 		sendLabel = serverCtSecretLabel
 		recvLabel = clientCtSecretLabel
 	}
-	connId := encodeArgs(c.clientConnId)
-	c.writeClear, err = newCryptoStateFromSecret(connId, sendLabel, &params)
+	c.writeClear, err = generateCleartextKeys(c.initialConnectionId, sendLabel, &params)
 	if err != nil {
 		return
 	}
-	c.readClear, err = newCryptoStateFromSecret(connId, recvLabel, &params)
+	c.readClear, err = generateCleartextKeys(c.initialConnectionId, recvLabel, &params)
 	if err != nil {
 		return
 	}
@@ -1880,21 +1812,33 @@ func (c *Connection) GetRecvStream(id uint64) RecvStream {
 	return nil
 }
 
-func generateRand64() (uint64, error) {
-	b := make([]byte, 8)
+func (c *Connection) randomConnectionId(size int) (ConnectionId, error) {
+	assert(size == 0 || (size >= 4 && size <= 18))
+	b := make([]byte, size)
 
-	_, err := rand.Read(b)
+	_, err := io.ReadFull(rand.Reader, b)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	ret := uint64(0)
+	return ConnectionId(b), nil
+}
+
+func (c *Connection) randomPacketNumber() error {
+	b := make([]byte, 4)
+
+	_, err := io.ReadFull(rand.Reader, b)
+	if err != nil {
+		return err
+	}
+
+	v := uint64(0)
 	for _, c := range b {
-		ret <<= 8
-		ret |= uint64(c)
+		v <<= 8
+		v |= uint64(c)
 	}
-
-	return ret, nil
+	c.nextSendPacket = v >> 1
+	return nil
 }
 
 // Set the handler class for a given connection.
@@ -1942,15 +1886,9 @@ func (c *Connection) GetState() State {
 	return c.state
 }
 
-// Get the connection ID for a connection. Returns 0 if
-// you are a client and the first server packet hasn't
-// been received.
-func (c *Connection) Id() ConnectionId {
-	return c.serverConnId
-}
-
+// ClientId returns the randomized initial connection ID chosen by the client.
 func (c *Connection) ClientId() ConnectionId {
-	return c.clientConnId
+	return c.initialConnectionId
 }
 
 func (c *Connection) handleError(e error) error {

--- a/connection_test.go
+++ b/connection_test.go
@@ -544,7 +544,8 @@ func TestVersionNegotiationPacket(t *testing.T) {
 	assertNotError(t, err, "Couldn't decode VN")
 	// Check the error.
 	assertEquals(t, hdr.Version, VersionNumber(0))
-	assertEquals(t, hdr.ConnectionID, client.clientConnId)
+	assertByteEquals(t, hdr.DestinationConnectionID, client.clientConnectionId)
+	assertByteEquals(t, hdr.SourceConnectionID, client.initialConnectionId)
 }
 
 func TestCantMakeRemoteStreams(t *testing.T) {

--- a/connection_test.go
+++ b/connection_test.go
@@ -545,7 +545,7 @@ func TestVersionNegotiationPacket(t *testing.T) {
 	// Check the error.
 	assertEquals(t, hdr.Version, VersionNumber(0))
 	assertByteEquals(t, hdr.DestinationConnectionID, client.clientConnectionId)
-	assertByteEquals(t, hdr.SourceConnectionID, client.initialConnectionId)
+	assertByteEquals(t, hdr.SourceConnectionID, client.serverConnectionId)
 }
 
 func TestCantMakeRemoteStreams(t *testing.T) {

--- a/crypto.go
+++ b/crypto.go
@@ -3,6 +3,7 @@ package minq
 import (
 	"crypto"
 	"crypto/cipher"
+	"encoding/hex"
 	"github.com/bifurcation/mint"
 )
 
@@ -11,7 +12,15 @@ type cryptoState struct {
 	aead   cipher.AEAD
 }
 
-var kQuicVersionSalt = []byte{0x9c, 0x10, 0x8f, 0x98, 0x52, 0x0a, 0x5c, 0x5c, 0x32, 0x96, 0x8e, 0x95, 0x0e, 0x8a, 0x2c, 0x5f, 0xe0, 0x6d, 0x6c, 0x38}
+func infallibleHexDecode(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic("didn't hex decode " + s)
+	}
+	return b
+}
+
+var kQuicVersionSalt = infallibleHexDecode("9c108f98520a5c5c32968e950e8a2c5fe06d6c38")
 
 const clientCtSecretLabel = "client hs"
 const serverCtSecretLabel = "server hs"

--- a/crypto.go
+++ b/crypto.go
@@ -3,7 +3,6 @@ package minq
 import (
 	"crypto"
 	"crypto/cipher"
-	"encoding/hex"
 	"github.com/bifurcation/mint"
 )
 
@@ -12,7 +11,7 @@ type cryptoState struct {
 	aead   cipher.AEAD
 }
 
-const kQuicVersionSalt = "afc824ec5fc77eca1e9d36f37fb2d46518c36639"
+var kQuicVersionSalt = []byte{0x9c, 0x10, 0x8f, 0x98, 0x52, 0x0a, 0x5c, 0x5c, 0x32, 0x96, 0x8e, 0x95, 0x0e, 0x8a, 0x2c, 0x5f, 0xe0, 0x6d, 0x6c, 0x38}
 
 const clientCtSecretLabel = "client hs"
 const serverCtSecretLabel = "server hs"
@@ -37,14 +36,8 @@ func newCryptoStateInner(secret []byte, cs *mint.CipherSuiteParams) (*cryptoStat
 	return &st, nil
 }
 
-func newCryptoStateFromSecret(secret []byte, label string, cs *mint.CipherSuiteParams) (*cryptoState, error) {
-	var err error
-
-	salt, err := hex.DecodeString(kQuicVersionSalt)
-	if err != nil {
-		panic("Bogus value")
-	}
-	extracted := mint.HkdfExtract(cs.Hash, salt, secret)
+func generateCleartextKeys(secret []byte, label string, cs *mint.CipherSuiteParams) (*cryptoState, error) {
+	extracted := mint.HkdfExtract(cs.Hash, kQuicVersionSalt, secret)
 	inner := QhkdfExpandLabel(cs.Hash, extracted, label, []byte{}, cs.Hash.Size())
 	return newCryptoStateInner(inner, cs)
 }

--- a/packet.go
+++ b/packet.go
@@ -2,6 +2,7 @@ package minq
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 )
 
@@ -14,28 +15,27 @@ Long header
 +-+-+-+-+-+-+-+-+
 |1|   Type (7)  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                                                               |
-+                       Connection ID (64)                      +
-|                                                               |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                         Version (32)                          |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       Packet Number (32)                      |
+|DCIL(4)|SCIL(4)|
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|               Destination Connection ID (0/32..144)         ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                 Source Connection ID (0/32..144)            ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       Payload Length (i)                    ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                     Packet Number (8/16/32)                   |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                          Payload (*)                        ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-
-Short Header
-
  0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 11
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+
-|0|C|K| Type (5)|
+|0|K|1|1|0|R R R|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                                                               |
-+                     [Connection ID (64)]                      +
-|                                                               |
+|                Destination Connection ID (0..144)           ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                      Packet Number (8/16/32)                ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -44,41 +44,93 @@ Short Header
 */
 
 const (
-	packetFlagLongHeader = 0x80
-	packetFlagC          = 0x40
-	packetFlagK          = 0x20
+	packetFlagLongHeader  = byte(0x80)
+	packetFlagK           = byte(0x40)
+	packetFlagShortHeader = byte(0x30)
 )
+
+// This packet type differs considerably from the spec.  It includes both
+// long and short headers in the same value space.  Long headers are from
+// 0-0x7f (inclusive); short headers are always represented as 0xff.
+type packetType byte
 
 const (
-	packetTypeInitial        = 0x7f
-	packetTypeRetry          = 0x7e
-	packetTypeHandshake      = 0x7d
-	packetType0RTTProtected  = 0x7c
-	packetTypeProtectedShort = 0xff // Not a real type
+	packetTypeInitial        = packetType(0x7f)
+	packetTypeRetry          = packetType(0x7e)
+	packetTypeHandshake      = packetType(0x7d)
+	packetType0RTTProtected  = packetType(0x7c)
+	packetTypeProtectedShort = packetType(0xff) // Not a real type
 )
 
-type ConnectionId uint64
-type version uint32
-
-// The PDU definition for the header.
-// These types are capitalized so that |codec| can use the,
-type packetHeader struct {
-	Type         byte
-	ConnectionID ConnectionId
-	Version      VersionNumber
-	PacketNumber uint64 // Never more than 32 bits on the wire.
+func (pt packetType) isLongHeader() bool {
+	return pt&packetType(packetFlagLongHeader) != 0
 }
 
-func (p *packetHeader) String() string {
+func (pt packetType) isProtected() bool {
+	if !pt.isLongHeader() {
+		return true
+	}
+
+	switch pt & 0x7f {
+	case packetTypeInitial, packetTypeHandshake, packetTypeRetry:
+		return false
+	}
+	return true
+}
+
+// ConnectionId identifies the connection that a packet belongs to.
+type ConnectionId []byte
+
+// String stringifies a connection ID in the natural way.
+func (c ConnectionId) String() string {
+	return hex.EncodeToString(c)
+}
+
+// EncodeLength produces the length encoding used in the long packet header.
+func (c ConnectionId) EncodeLength() byte {
+	if len(c) == 0 {
+		return 0
+	}
+	assert(len(c) >= 4 && len(c) <= 18)
+	return byte(len(c) - 3)
+}
+
+// The PDU definition for the header.
+// These types are capitalized so that |codec| can use them.
+type packetHeader struct {
+	// Type is the on-the-wire form of the packet type.
+	// Consult getHeaderType if you want a value that corresponds to the
+	// definition of packetType.
+	Type                    packetType
+	ConnectionIDLengths     byte
+	DestinationConnectionID ConnectionId
+	SourceConnectionID      ConnectionId
+	Version                 VersionNumber
+	PayloadLength           uint64 `tls:"varint"`
+	PacketNumber            uint64 // Never more than 32 bits on the wire.
+
+	// In order to decode a short header, the length of the connection
+	// ID must be set in |shortCidLength| before decoding.
+	shortCidLength uintptr
+}
+
+func (p packetHeader) String() string {
 	ht := "SHORT"
-	if isLongHeader(p) {
+	if p.Type.isLongHeader() {
 		ht = "LONG"
 	}
 	prot := "CLEAR"
-	if p.isProtected() {
+	if p.Type.isProtected() {
 		prot = "ENC"
 	}
-	return fmt.Sprintf("%s %s PT=%x", ht, prot, p.getHeaderType())
+	return fmt.Sprintf("%s %s PT=%x PN=%x", ht, prot, p.getHeaderType(), p.PacketNumber)
+}
+
+func (p *packetHeader) getHeaderType() packetType {
+	if p.Type.isLongHeader() {
+		return p.Type & 0x7f
+	}
+	return packetTypeProtectedShort
 }
 
 type packet struct {
@@ -86,77 +138,88 @@ type packet struct {
 	payload []byte
 }
 
-// Functions to support encoding and decoding.
-func isSet(b byte, flag byte) bool {
-	return (b & flag) != 0
+// This reads from p.ConnectionIDLengths.
+func (p packetHeader) ConnectionIDLengths__length() uintptr {
+	if p.Type.isLongHeader() {
+		return 1
+	}
+	return 0
 }
 
-func isLongHeader(p *packetHeader) bool {
-	return isSet(p.Type, packetFlagLongHeader)
+func (p packetHeader) DestinationConnectionID__length() uintptr {
+	if !p.Type.isLongHeader() {
+		return p.shortCidLength
+	}
+	l := p.ConnectionIDLengths >> 4
+	if l != 0 {
+		l += 3
+	}
+	return uintptr(l)
 }
 
-func (p *packetHeader) isProtected() bool {
-	if !isLongHeader(p) {
-		return true
+func (p packetHeader) SourceConnectionID__length() uintptr {
+	if !p.Type.isLongHeader() {
+		return 0
 	}
-
-	switch p.Type & 0x7f {
-	case packetTypeInitial, packetTypeHandshake, packetTypeRetry:
-		return false
+	l := p.ConnectionIDLengths & 0xf
+	if l != 0 {
+		l += 3
 	}
-	return true
+	return uintptr(l)
 }
 
-func (p *packetHeader) hasConnId() bool {
-	if isLongHeader(p) {
-		return true
+func (p packetHeader) PayloadLength__length() uintptr {
+	if p.Type.isLongHeader() {
+		return codecDefaultSize
 	}
-	if (p.Type & packetFlagC) == 0 {
-		return true
-	}
-	return false
-}
-
-func (p *packetHeader) getHeaderType() byte {
-	if isLongHeader(p) {
-		return p.Type & 0x7f
-	}
-	return packetTypeProtectedShort
-}
-
-func (p packetHeader) ConnectionID__length() uintptr {
-	if isLongHeader(&p) || !isSet(p.Type, packetFlagC) {
-		return 8
-	}
-	return codecDefaultSize
+	return 0
 }
 
 func (p packetHeader) PacketNumber__length() uintptr {
 	logf(logTypeTrace, "PacketNumber__length() Type=%v", p.Type)
-	if isLongHeader(&p) {
+	if p.Type.isLongHeader() {
 		return 4
 	}
 
-	switch p.Type & 0x3f {
-	case 0x1f:
+	switch p.Type & 0x3 {
+	case 0:
 		return 1
-	case 0x1e:
+	case 1:
 		return 2
-	case 0x1d:
+	case 2:
 		return 4
 	default:
 		return 4 // TODO(ekr@rtfm.com): This is actually currently an error.
 	}
 }
 func (p packetHeader) Version__length() uintptr {
-	if isLongHeader(&p) {
+	if p.Type.isLongHeader() {
 		return 4
 	}
 	return 0
 }
 
-func (p *packetHeader) setLongHeaderType(typ byte) {
-	p.Type = packetFlagLongHeader | typ
+func newPacket(pt packetType, destCid ConnectionId, srcCid ConnectionId, ver VersionNumber, pn uint64, payload []byte) *packet {
+	if pt == packetTypeProtectedShort {
+		// Only support writing the 32-bit packet number.
+		pt = packetType(0x2 | packetFlagShortHeader)
+		srcCid = nil
+	} else {
+		pt = pt | packetType(packetFlagLongHeader)
+	}
+	lengths := (destCid.EncodeLength() << 4) | srcCid.EncodeLength()
+	return &packet{
+		packetHeader: packetHeader{
+			Type:                    pt,
+			ConnectionIDLengths:     lengths,
+			DestinationConnectionID: destCid,
+			SourceConnectionID:      srcCid,
+			Version:                 ver,
+			PayloadLength:           uint64(len(payload)),
+			PacketNumber:            pn,
+		},
+		payload: payload,
+	}
 }
 
 type versionNegotiationPacket struct {

--- a/packet.go
+++ b/packet.go
@@ -80,7 +80,7 @@ func (pt packetType) isProtected() bool {
 
 // kCidDefaultLength is the length of connection ID we generate.
 // TODO: make this configurable.
-const kCidDefaultLength = 8
+const kCidDefaultLength = 5
 
 // ConnectionId identifies the connection that a packet belongs to.
 type ConnectionId []byte

--- a/packet.go
+++ b/packet.go
@@ -78,6 +78,10 @@ func (pt packetType) isProtected() bool {
 	return true
 }
 
+// kCidDefaultLength is the length of connection ID we generate.
+// TODO: make this configurable.
+const kCidDefaultLength = 8
+
 // ConnectionId identifies the connection that a packet belongs to.
 type ConnectionId []byte
 

--- a/server.go
+++ b/server.go
@@ -37,7 +37,7 @@ func (s *Server) SetHandler(h ServerHandler) {
 // Input passes an incoming packet to the Server.
 func (s *Server) Input(addr *net.UDPAddr, data []byte) (*Connection, error) {
 	logf(logTypeServer, "Received packet from %v", addr)
-	hdr := packetHeader{shortCidLength: 8}
+	hdr := packetHeader{shortCidLength: kCidDefaultLength}
 	newConn := false
 
 	_, err := decode(&hdr, data)


### PR DESCRIPTION
Getting the packet header decoding working was a little difficult.  In the end I opted to partially teach your codec about `tls:"varint"` so that I could encode the packet number (the alternative was to encode it as two octets always, which was tempting, but would have made decoding hard still).  I'm not happy with the way that I am decoding the short packet header, but it's the best I could come up with on short notice.  If you have a better idea, I'd really like to hear it.

I updated the per-version salt, bumped the packet number, changed the calculation of per-packet overheads (it makes more sense to do that with a variable-length connection ID).

It might make sense to have configuration for the length of the connection ID, but I hard-coded that to 8 for now.  You don't have any means of configuring a connection/server, so that seemed hard enough that I wanted to punt on it.

There are three connection ID fields in Connection now, the initial is saved separate to client/server CIDs.  Using those simplified things a bit, so I refactored some code around sending packets, especially version negotiation, which had a special function that I just inlined since VN was the only user.  Also, in using those new fields, I noticed that there was an entirely unused function, which is now gone.