### PR TITLE
Suppress retransmission for frames that don't need it

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -504,7 +504,7 @@ func TestSendReceiveStreamRst(t *testing.T) {
 	cs.Write(testString)
 
 	// Now reset the stream.
-	cs.Reset(kQuicErrorNoError)
+	cs.Reset(0)
 
 	// Verify that we cannot write.
 	n, err := cs.Write(testString)
@@ -729,7 +729,7 @@ func TestUnidirectionalStreamRst(t *testing.T) {
 	assertNotNil(t, d, "Read data from server")
 	assertByteEquals(t, d, testString)
 
-	err = sstream.Reset(kQuicErrorNoError)
+	err = sstream.Reset(77)
 	assertNotError(t, err, "reset works")
 
 	err = inputAll(client)
@@ -746,7 +746,7 @@ func TestUnidirectionalStreamRstImmediate(t *testing.T) {
 	pair.handshake(t)
 
 	sstream := pair.server.CreateSendStream()
-	err := sstream.Reset(kQuicErrorNoError)
+	err := sstream.Reset(45)
 	assertNotError(t, err, "reset works")
 
 	err = inputAll(pair.client)
@@ -945,7 +945,7 @@ func TestConnectionLevelFlowControlRst(t *testing.T) {
 
 	// Connection flow control should be exhausted now.
 	// Now reset one of those streams.
-	cstreams[0].Reset(kQuicErrorNoError)
+	cstreams[0].Reset(32)
 	inputAll(pair.server)
 
 	// Now let the MAX_DATA frame propagate and check that we can write again.

--- a/frame_test.go
+++ b/frame_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func testEncodeDecodeEncode(t *testing.T, f frame) {
+func testEncodeDecodeEncode(t *testing.T, f *frame) {
 	err := f.encode()
 	assertNotError(t, err, "Encode failed")
 	fmt.Printf("Encoded: [%x]\n", f.encoded)
@@ -39,7 +39,7 @@ func TestAckFrameOneRange(t *testing.T) {
 	f, _, err := newAckFrame(recvd, ar, 33)
 	assertNotError(t, err, "Couldn't make ack frame")
 
-	testEncodeDecodeEncode(t, *f)
+	testEncodeDecodeEncode(t, f)
 }
 
 func TestAckFrameTwoRanges(t *testing.T) {
@@ -52,7 +52,7 @@ func TestAckFrameTwoRanges(t *testing.T) {
 	f, _, err := newAckFrame(recvd, ar, 49)
 	assertNotError(t, err, "Couldn't make ack frame")
 
-	testEncodeDecodeEncode(t, *f)
+	testEncodeDecodeEncode(t, f)
 }
 
 func TestFixedSizedData(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -459,12 +459,12 @@ func (s *recvStreamBase) handleReset(offset uint64) error {
 		s.fc.used = offset
 	case RecvStreamStateDataRecvd, RecvStreamStateResetRead:
 		panic("we don't use this state")
-	case RecvStreamStateSizeKnown, RecvStreamStateDataRead:
+	case RecvStreamStateSizeKnown, RecvStreamStateDataRead, RecvStreamStateResetRecvd:
 		if offset != s.fc.used {
 			return ErrorProtocolViolation
 		}
 	default:
-		panic("unknown state")
+		panic(fmt.Sprintf("unknown state %v", s.state))
 	}
 
 	s.setRecvState(RecvStreamStateResetRecvd)
@@ -685,7 +685,7 @@ type streamSet struct {
 	t streamType
 	// role is the endpoint's role
 	role Role
-	// max is the maximum number of streams (as opposed to the maximum ID)
+	// nstreams is the maximum number of streams (as opposed to the maximum ID)
 	nstreams int
 	// typeless array of streams because go doesn't have generics
 	streams []hasIdentity


### PR DESCRIPTION
This required some fairly heavy refactoring of the queues for frames.  Working on literal frames is nice in theory, but I removed that in the end because pointers are much easier to work with when you have to update the items in the list.

I notice that you tend to send ACK frames last, relying on the fragment size of STREAM frames being smaller than the MTU.  That's not ideal and I'd prefer to load ACKs up front, but that's a bigger change.

https://phabricator.services.mozilla.com/D1309
