### PR TITLE
Compound packets

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -481,7 +481,7 @@ func (c *Connection) sendPacketRaw(pt packetType, version VersionNumber, pn uint
 		destCid = c.clientConnectionId
 	}
 
-	p := newPacket(pt, destCid, srcCid, version, pn, payload)
+	p := newPacket(pt, destCid, srcCid, version, pn, payload, aead.Overhead())
 	c.logPacket("Sending", &p.packetHeader, pn, payload)
 
 	// Encode the header so we know how long it is.
@@ -879,7 +879,7 @@ func (c *Connection) fireReadable() {
 	})
 }
 
-func (c *Connection) input(p []byte) error {
+func (c *Connection) input(payload []byte) error {
 	if c.isClosed() {
 		return ErrorConnIsClosed
 	}
@@ -896,13 +896,21 @@ func (c *Connection) input(p []byte) error {
 
 	hdr := packetHeader{shortCidLength: kCidDefaultLength}
 
-	c.log(logTypeTrace, "Receiving packet len=%v %v", len(p), hex.EncodeToString(p))
-	hdrlen, err := decode(&hdr, p)
+	c.log(logTypeTrace, "Receiving packet len=%v %v", len(payload), hex.EncodeToString(payload))
+	hdrlen, err := decode(&hdr, payload)
 	if err != nil {
-		c.log(logTypeConnection, "Could not decode packetX: %v", hex.EncodeToString(p))
+		c.log(logTypeConnection, "Could not decode packetX: %v", hex.EncodeToString(payload))
 		return wrapE(ErrorInvalidPacket, err)
 	}
-	assert(int(hdrlen) <= len(p))
+	assert(int(hdrlen) <= len(payload))
+
+	var remainder []byte
+	thisPacketLen := int(hdrlen + uintptr(hdr.PayloadLength))
+	if hdr.Type.isLongHeader() && thisPacketLen < len(payload) {
+		c.log(logTypeTrace, "Compound packet %x first part=%d", hdr.PacketNumber, len(payload)-thisPacketLen)
+		remainder = payload[thisPacketLen:]
+		payload = payload[:thisPacketLen]
+	}
 
 	if hdr.Type.isLongHeader() && hdr.Version != c.version {
 		if c.role == RoleServer {
@@ -925,11 +933,11 @@ func (c *Connection) input(p []byte) error {
 	}
 
 	typ := hdr.getHeaderType()
-	c.log(logTypeTrace, "Received packet %x len=%d", hdr.PacketNumber, len(p))
+	c.log(logTypeTrace, "Received packet %x len=%d", hdr.PacketNumber, len(payload))
 	c.log(logTypeConnection, "Packet header %v, %d", hdr, typ)
 
 	if hdr.Type.isLongHeader() && hdr.Version == 0 {
-		return c.processVersionNegotiation(&hdr, p[hdrlen:])
+		return c.processVersionNegotiation(&hdr, payload[hdrlen:])
 	}
 
 	if c.state == StateWaitClientInitial {
@@ -974,16 +982,17 @@ func (c *Connection) input(p []byte) error {
 		return nonFatalError(fmt.Sprintf("Duplicate packet id %x", packetNumber))
 	}
 
-	payload, err := aead.Open(nil, c.packetNonce(packetNumber), p[hdrlen:], p[:hdrlen])
+	plaintext, err := aead.Open(nil, c.packetNonce(packetNumber),
+		payload[hdrlen:], payload[:hdrlen])
 	if err != nil {
-		c.log(logTypeConnection, "Could not unprotect packet %x", p)
-		c.log(logTypeTrace, "Packet %h", p)
+		c.log(logTypeConnection, "Could not unprotect packet %x", payload)
+		c.log(logTypeTrace, "Packet %h", payload)
 		return wrapE(ErrorInvalidPacket, err)
 	}
 
 	// Now that we know it's valid, process stateless retry.
 	if typ == packetTypeRetry {
-		return c.processStatelessRetry(&hdr, payload)
+		return c.processStatelessRetry(&hdr, plaintext)
 	}
 
 	if !c.recvd.initialized() {
@@ -993,16 +1002,16 @@ func (c *Connection) input(p []byte) error {
 
 	// We have now verified that this is a valid packet, so mark
 	// it received.
-	c.logPacket("Received", &hdr, packetNumber, payload)
+	c.logPacket("Received", &hdr, packetNumber, plaintext)
 
 	naf := true
 	switch typ {
 	case packetTypeInitial:
-		err = c.processClientInitial(&hdr, payload)
+		err = c.processClientInitial(&hdr, plaintext)
 	case packetTypeHandshake:
-		err = c.processCleartext(&hdr, payload, &naf)
+		err = c.processCleartext(&hdr, plaintext, &naf)
 	case packetTypeProtectedShort:
-		err = c.processUnprotected(&hdr, packetNumber, payload, &naf)
+		err = c.processUnprotected(&hdr, packetNumber, plaintext, &naf)
 	default:
 		c.log(logTypeConnection, "Unsupported packet type %v", typ)
 		err = internalError("Unsupported packet type %v", typ)
@@ -1031,7 +1040,10 @@ func (c *Connection) input(p []byte) error {
 		}
 	}
 
-	return err
+	if remainder != nil {
+		return c.input(remainder)
+	}
+	return nil
 }
 
 func (c *Connection) processClientInitial(hdr *packetHeader, payload []byte) error {
@@ -1276,7 +1288,7 @@ func (c *Connection) sendVersionNegotiation(hdr packetHeader) error {
 
 	c.log(logTypeConnection, "Sending version negotiation packet")
 	p := newPacket(packetType(pt[0]&0x7f), hdr.SourceConnectionID, hdr.DestinationConnectionID,
-		0, hdr.PacketNumber, payload)
+		0, hdr.PacketNumber, payload, 0)
 
 	header, err := encode(&p.packetHeader)
 	if err != nil {

--- a/packet.go
+++ b/packet.go
@@ -203,7 +203,7 @@ func (p packetHeader) Version__length() uintptr {
 	return 0
 }
 
-func newPacket(pt packetType, destCid ConnectionId, srcCid ConnectionId, ver VersionNumber, pn uint64, payload []byte) *packet {
+func newPacket(pt packetType, destCid ConnectionId, srcCid ConnectionId, ver VersionNumber, pn uint64, payload []byte, aeadOverhead int) *packet {
 	if pt == packetTypeProtectedShort {
 		// Only support writing the 32-bit packet number.
 		pt = packetType(0x2 | packetFlagShortHeader)
@@ -219,7 +219,7 @@ func newPacket(pt packetType, destCid ConnectionId, srcCid ConnectionId, ver Ver
 			DestinationConnectionID: destCid,
 			SourceConnectionID:      srcCid,
 			Version:                 ver,
-			PayloadLength:           uint64(len(payload)),
+			PayloadLength:           uint64(len(payload) + aeadOverhead),
 			PacketNumber:            pn,
 		},
 		payload: payload,

--- a/packet_test.go
+++ b/packet_test.go
@@ -33,13 +33,13 @@ func packetHeaderEDE(t *testing.T, p *packetHeader, cidLen uintptr) {
 
 func TestLongHeader(t *testing.T) {
 	p := newPacket(packetTypeInitial, testCid7, testCid4, testVersion,
-		testPn, make([]byte, 65))
+		testPn, make([]byte, 65), 16)
 	packetHeaderEDE(t, &p.packetHeader, 0)
 }
 
 func TestShortHeader(t *testing.T) {
 	p := newPacket(packetTypeProtectedShort, testCid7, testCid4, testVersion,
-		testPn, make([]byte, 65))
+		testPn, make([]byte, 65), 16)
 
 	// We have to provide assistance to the decoder for short headers.
 	// Otherwise, it can't know long the destination connection ID is.


### PR DESCRIPTION
This adds proper support for compound packets, and a test for reading them.

In the previous patch I failed to account for AEAD expansion in the construction of the header.